### PR TITLE
Fix explicit version curl 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "require": {
     "php": "^7.0.8",
-    "ext-curl": "^7.2"
+    "ext-curl": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
Fix error :" kennisnet/edurepsearch dev-master requires ext-curl ^7.2 -> the requested PHP extension curl has the wrong version (7.0.33-0+deb9u1) installed."