### PR TITLE
Removed restraints of maximum records and start record when using catalogus strategy and cleaned up tests to use one consistent style

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "scripts": {
+    "install-composer": "composer install",
     "test": "vendor/bin/phpunit",
     "test:coverage": "vendor/bin/phpunit --coverage-html .coverage",
     "analyse": "vendor/bin/phpstan analyse"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "scripts": {
-    "install-composer": "composer install",
     "test": "vendor/bin/phpunit",
     "test:coverage": "vendor/bin/phpunit --coverage-html .coverage",
     "analyse": "vendor/bin/phpstan analyse"

--- a/src/EdurepSearch.php
+++ b/src/EdurepSearch.php
@@ -71,6 +71,11 @@ class EdurepSearch
         $this->searchClient = $searchClient;
     }
 
+    private function isCatalogusStrategy(StrategyType $strategyType): bool
+    {
+        return $strategyType instanceof \Kennisnet\Edurep\Strategy\CatalogusStrategyType;
+    }
+
     /**
      * @param int $value
      *
@@ -78,13 +83,20 @@ class EdurepSearch
      */
     public function setMaximumRecords(int $value): self
     {
-        if ($value >= 0 && $value <= self::MAX_RECORDS) {
-            $this->parameters["maximumRecords"] = $value;
-        } else {
-            throw new UnexpectedValueException("The value for maximumRecords should be between 0 and 100.", 22);
+        $isCatalogusStrategy = $this->isCatalogusStrategy($this->config->getStrategy());
+
+        if (self::isMaximumRecordsOutsideSelectedRange($value) && !$isCatalogusStrategy) {
+            throw new UnexpectedValueException("The value for maximumRecords should be between 0 and " . self::MAX_RECORDS . ".", 22);
         }
 
+        $this->parameters["maximumRecords"] = $value;
+
         return $this;
+    }
+
+    private static function isMaximumRecordsOutsideSelectedRange(int $value): bool
+    {
+        return ($value < 0 || $value > self::MAX_RECORDS);
     }
 
     public function setRecordpacking(string $recordPacking): self
@@ -142,15 +154,22 @@ class EdurepSearch
      */
     public function setStartRecord(int $value): self
     {
-        if ($value >= 1 && $value <= self::EDUREP_MAX_STARTRECORD) {
-            $this->parameters["startRecord"] = $value;
-            $this->availablestartrecords     = self::EDUREP_MAX_STARTRECORD - $value;
-        } else {
+        $isCatalogusStrategy = $this->isCatalogusStrategy($this->config->getStrategy());
+
+        if (self::isStartRecordOutsideSelectedRange($value) && !$isCatalogusStrategy) {
             throw new UnexpectedValueException("The value for startRecords should be between 1 and " . self::EDUREP_MAX_STARTRECORD . ".",
-                                               23);
+                23);
         }
 
+        $this->parameters["startRecord"] = $value;
+        $this->availablestartrecords     = self::EDUREP_MAX_STARTRECORD - $value;
+
         return $this;
+    }
+
+    private static function isStartRecordOutsideSelectedRange(int $value): bool
+    {
+        return ($value < 1 || $value > self::EDUREP_MAX_STARTRECORD);
     }
 
     public function addXRecordSchema(string $value): self
@@ -209,7 +228,9 @@ class EdurepSearch
     {
         # making sure the startRecord/maximumRecord combo does
         # not trigger an exception.
-        if ($this->availablestartrecords < $this->parameters["maximumRecords"]) {
+        $isNotCatalogusStrategy = !$this->isCatalogusStrategy($this->config->getStrategy());
+
+        if (($this->availablestartrecords < $this->parameters["maximumRecords"]) && $isNotCatalogusStrategy) {
             $this->parameters["maximumRecords"] = $this->availablestartrecords;
         }
 

--- a/tests/EdurepSearchTest.php
+++ b/tests/EdurepSearchTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Kennisnet\Edurep;
 
-
 use Kennisnet\Edurep\DefaultSearchConfig;
 use Kennisnet\Edurep\EdurepSearch;
 use Kennisnet\Edurep\SearchClient;
@@ -13,30 +12,87 @@ use PHPUnit\Framework\TestCase;
 class EdurepSearchTest extends TestCase
 {
 
-    public function testInvalidMax(): void
+    public function test_exception_thrown_on_setting_invalid_maximum_records_value(): void
     {
+        $strategy = new EdurepStrategyType();
+        $config   = new DefaultSearchConfig($strategy, "http://wszoeken.edurep.kennisnet.nl:8000/");
+        $edurep   = new EdurepSearch($config);
+
         $this->expectExceptionMessage('The value for maximumRecords should be between 0 and 100.');
 
+        $edurep->setMaximumRecords(-1);
+    }
+
+    public function test_exception_thrown_on_missing_query_when_getting_request_url(): void
+    {
         $strategy = new EdurepStrategyType();
         $config   = new DefaultSearchConfig($strategy, "http://wszoeken.edurep.kennisnet.nl:8000/");
         $edurep   = new EdurepSearch($config);
 
-        $edurep->setMaximumRecords(-1);
-        $edurep->getRequestUrl();
-    }
-
-    public function testNoQuery(): void
-    {
         $this->expectExceptionMessage('Missing query');
 
+        $edurep->getRequestUrl();
+    }
+
+    public function test_catalogus_can_set_infinitely_high_start_record(): void
+    {
+        $strategy = new CatalogusStrategyType();
+        $config = new DefaultSearchConfig($strategy, "https://staging.catalogusservice.edurep.nl/");
+        $edurep = new EdurepSearch($config);
+
+        $edurep->setStartRecord(3000);
+        $edurep->setQuery("mbo");
+
+        $this->assertEquals(
+            'https://staging.catalogusservice.edurep.nl/sru?operation=searchRetrieve&version=1.2&recordPacking=xml&query=mbo&maximumRecords=100&startRecord=3000',
+            $edurep->getRequestUrl(),
+            "Test catalogus URL with startRecord 3000"
+        );
+
+        $this->assertEquals(3000, $edurep->getParameters()['startRecord'], "Test catalogus can use unrestrained start record");
+    }
+
+    public function test_catalogus_can_set_infinitely_high_maximum_records(): void
+    {
+        $strategy = new CatalogusStrategyType();
+        $config   = new DefaultSearchConfig($strategy, "https://staging.catalogusservice.edurep.nl/");
+        $edurep   = new EdurepSearch($config);
+
+        $edurep->setMaximumRecords(1000);
+        $edurep->setQuery("mbo");
+
+        $this->assertEquals(
+            'https://staging.catalogusservice.edurep.nl/sru?operation=searchRetrieve&version=1.2&recordPacking=xml&query=mbo&maximumRecords=1000',
+            $edurep->getRequestUrl(),
+            "Test catalogus URL with maximumRecords 1000"
+        );
+
+        $this->assertEquals(1000, $edurep->getParameters()['maximumRecords'], "Test catalogus can use unrestrained maxiumum records");
+    }
+
+    public function test_edurep_cant_use_unrestrained_maximum_records(): void
+    {
         $strategy = new EdurepStrategyType();
         $config   = new DefaultSearchConfig($strategy, "http://wszoeken.edurep.kennisnet.nl:8000/");
         $edurep   = new EdurepSearch($config);
 
-        $edurep->getRequestUrl();
+        $this->expectExceptionMessage('The value for maximumRecords should be between 0 and 100.');
+
+        $edurep->setMaximumRecords(1000);
     }
 
-    public function testEdurepQuery(): void
+    public function test_edurep_cant_use_unrestrained_start_record(): void
+    {
+        $strategy = new EdurepStrategyType();
+        $config   = new DefaultSearchConfig($strategy, "http://wszoeken.edurep.kennisnet.nl:8000/");
+        $edurep   = new EdurepSearch($config);
+
+        $this->expectExceptionMessage('The value for startRecords should be between 1 and 1000.');
+
+        $edurep->setStartRecord(3000);
+    }
+
+    public function test_edurep_query(): void
     {
         $strategy = new EdurepStrategyType();
         $config   = new DefaultSearchConfig($strategy, "http://wszoeken.edurep.kennisnet.nl:8000/");
@@ -76,7 +132,7 @@ class EdurepSearchTest extends TestCase
         );
     }
 
-    public function testCatalogQuery(): void
+    public function test_catalogus_query(): void
     {
         $strategy = new CatalogusStrategyType();
         $config   = new DefaultSearchConfig($strategy, "https://staging.catalogusservice.edurep.nl/");
@@ -101,7 +157,7 @@ class EdurepSearchTest extends TestCase
         );
     }
 
-    public function testDefaultSearch()
+    public function test_default_search()
     {
         $strategy     = new EdurepStrategyType();
         $config       = new DefaultSearchConfig($strategy, "http://wszoeken.edurep.kennisnet.nl:8000/");


### PR DESCRIPTION
Currently when the catalogus website goes above page 100 it cant get the right records back due to startRecord and maximumRecords being above the allowed value. 

To solve this I changed it so when using the Catalogus strategy the limitations on the maximum value gets ignored.

It should be looked into if keeping these limitations for other strategies is needed.

On top of that I renamed the tests to be more consistent with other projects and overall clearer as in the current situation they did no describe the tests clearly.